### PR TITLE
Update php-fpm.conf

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -24,7 +24,7 @@ pid = run/php-fpm.pid
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; in a local file.
 ; Default Value: log/php-fpm.log
-error_log = log/php-fpm.log
+; error_log = log/php-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities


### PR DESCRIPTION
error_log string - Path to error log file. Default value: #INSTALL_PREFIX#/log/php-fpm.log. If it's set to "syslog", log is sent to syslogd instead of being written in a local file.  Prefix value set on compilation yields no logs.  Better to use direct path than this ambiguous directory.