### PR TITLE
Update nginx_cache.conf

### DIFF
--- a/rpmdata/files/etc/nginx/conf.d/nginx_cache.conf
+++ b/rpmdata/files/etc/nginx/conf.d/nginx_cache.conf
@@ -1,7 +1,8 @@
 #PROXYCACHE
-proxy_cache_path /var/cache/nginx/proxycache levels=1:2 keys_zone=PROXYCACHE:32m inactive=60m max_size=512m;
+proxy_cache_path /dev/shm/proxycache levels=1:2 keys_zone=PROXYCACHE:5m inactive=60m max_size=512m;
 proxy_cache_key "$scheme$request_method$host$request_uri";
+proxy_cache_valid 200 302 10m;
+proxy_cache_valid 404 1m;
 #FASTCGICACHE
-fastcgi_cache_path /var/cache/nginx/fastcgicache levels=1:2 keys_zone=FASTCGICACHE:32m inactive=60m max_size=512m;
+fastcgi_cache_path /dev/shm/fastcgicache levels=1:2 keys_zone=FASTCGICACHE:5m inactive=60m max_size=512m;
 fastcgi_cache_key "$scheme$request_method$host$request_uri";
-


### PR DESCRIPTION
Store Proxy_Cache and FastCGI_Cachein physical memory (like Varnish) instead of using disk.  Would suggest lowering time content will be cached since until purged, as other users can access user-related data.  Added valid cache times for header returns.